### PR TITLE
PLANET-2604 fix gpiml upload

### DIFF
--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -27,6 +27,11 @@ jQuery(document).ready(function () {
             console.log(errorThrown); //eslint-disable-line no-console
         });
     });
+
+    // Hide the 'Insert to post' button.
+    $(document).on('click', '.media-menu-item:last-of-type', function() {
+		$( '.media-button-insert').css('visibility', 'hidden');
+    });
 });
 
 // Get file name from full url/path.

--- a/admin/js/adminml.js
+++ b/admin/js/adminml.js
@@ -29,7 +29,7 @@ jQuery(document).ready(function () {
 
 
     // Add click event for media insert button.
-    $( '#ml-button-insert' ).off('click').on('click', function () {
+	$(document).off('click').on('click', '#ml-button-insert', function () {
 
         var selected_images = $( '.ui-selected' ).map(function (index, element) {
             return $( element ).data( 'id' );
@@ -90,12 +90,19 @@ jQuery(document).ready(function () {
                     }
                     //TODO handle promises results/errors better.
                     Promise.all(promises).then(function (values) {
-                        parent.send_to_editor(values.join(' '));
+						// If this page contains a wp editor then insert the selected image inside the editor.
+						if ( "function" === typeof parent.send_to_editor ) {
+							parent.send_to_editor(values.join(' '));
+						}
                     });
                 }
             } catch (e) {
             }
             $( '#ml_spinner' ).removeClass('is-active');
+			// If this is not a page with a wp editor, then move to the Media Library page.
+			if ( "function" !== typeof parent.send_to_editor ) {
+				parent.window.location.replace('/wp-admin/upload.php');
+			}
 
         }).fail(function (jqXHR, textStatus, errorThrown) {
             console.log(errorThrown); //eslint-disable-line no-console

--- a/classes/controller/tab/class-gpi-media-library-controller.php
+++ b/classes/controller/tab/class-gpi-media-library-controller.php
@@ -191,7 +191,7 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 			];
 
 			wp_enqueue_style( 'p4ml_admin_style', P4ML_ADMIN_DIR . 'css/admin.css', [ 'media-views', 'media' ], '0.9' );
-			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/adminml.js', [], '0.10', true );
+			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/adminml.js', [], '0.11', true );
 			wp_localize_script( 'p4ml_admin_script', 'media_library_params', $params );
 			wp_enqueue_script( 'jquery-ui-core' );
 			wp_enqueue_script( 'jquery-ui-selectable' );

--- a/planet4-gpi-media-library.php
+++ b/planet4-gpi-media-library.php
@@ -3,7 +3,7 @@
  * Plugin Name: Planet4 - Gpi Media Library
  * Description: Connects Planet4 with the Media Library platform.
  * Plugin URI: http://github.com/greenpeace/planet4-plugin-medialibrary
- * Version: 1.2
+ * Version: 1.3
  * Php Version: 7.0
  *
  * Author: Greenpeace International


### PR DESCRIPTION
Fix issues with the GPI ML modal. Move to WP ML after selecting an im…age and clicking insert. If we are inside a page with an editor then we insert the selected image inside the editor. Hide the default Insert into post/page buttons of the WP Media Editor when inside the GPI ML tab.