### PR TITLE
PLANET-2693 GPI Media library: Images not loading for the carousel header block

### DIFF
--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -199,10 +199,8 @@ function scroll_ml_images() {
             // Append the response at the bottom of the results.
             $( '.ml-media-list' ).append( response );
 
-            // Add a throttle to avoid multiple scroll events from firing together.
-            setTimeout(function () {
-                scroll_more = 0;
-            }, 1500);
+            //Set back to zero to allow loading to be triggered on scroll again
+            scroll_more = 0;
         }).fail(function ( jqXHR, textStatus, errorThrown ) {
             console.log(errorThrown); //eslint-disable-line no-console
             scroll_more = 0;

--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -199,7 +199,7 @@ function scroll_ml_images() {
             // Append the response at the bottom of the results.
             $( '.ml-media-list' ).append( response );
 
-            //Set back to zero to allow loading to be triggered on scroll again
+            // Set back to zero to allow loading to be triggered on scroll again.
             scroll_more = 0;
         }).fail(function ( jqXHR, textStatus, errorThrown ) {
             console.log(errorThrown); //eslint-disable-line no-console


### PR DESCRIPTION
There was a setTimeout function that was allowing you to scroll to the bottom of the page without any scroll events firing. once at the bottom of the page no more scroll events could fire so it seemed like it was 'doing nothing'

ref: https://jira.greenpeace.org/browse/PLANET-2693