### PR TITLE
PLANET-2693 GPI Media library: Images not loading for the carousel header block

### DIFF
--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -199,10 +199,8 @@ function scroll_ml_images() {
             // Append the response at the bottom of the results.
             $( '.ml-media-list' ).append( response );
 
-            // Add a throttle to avoid multiple scroll events from firing together.
-            setTimeout(function () {
-                scroll_more = 0;
-            }, 1500);
+            //Set back to zero to allow loading to be triggered on scroll again
+            scroll_more = 0;
         }).fail(function ( jqXHR, textStatus, errorThrown ) {
             console.log(errorThrown); //eslint-disable-line no-console
             scroll_more = 0;

--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -25,6 +25,7 @@ jQuery(document).ready(function () {
             $( '.ml_spinner' ).remove();
             // Show the search query response.
             $( '.media-frame-content:last' ).append( response );
+            $( '.media-frame-content' ).attr( 'data-columns', '7' );
             $( '.ml-media-sidebar' ).hide();
 
             // Inject ml-media-panel in the attachments browser

--- a/admin/js/admin_search_ml.js
+++ b/admin/js/admin_search_ml.js
@@ -199,7 +199,7 @@ function scroll_ml_images() {
             // Append the response at the bottom of the results.
             $( '.ml-media-list' ).append( response );
 
-            //Set back to zero to allow loading to be triggered on scroll again
+            // Set back to zero to allow loading to be triggered on scroll again.
             scroll_more = 0;
         }).fail(function ( jqXHR, textStatus, errorThrown ) {
             console.log(errorThrown); //eslint-disable-line no-console

--- a/classes/controller/class-api-controller.php
+++ b/classes/controller/class-api-controller.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 		const ML_AUTH_URL     = self::ML_BASE_URL . '/API/Authentication/v1.0/Login';
 		const ML_SEARCH_URL   = self::ML_BASE_URL . '/API/search/v3.0/search';
 		const ML_CALL_TIMEOUT = 10;            // Seconds after which the api call will timeout if not responded.
-		const MEDIAS_PER_PAGE = 20;
+		const MEDIAS_PER_PAGE = 30;
 
 		const ERROR   = 0;
 		const WARNING = 1;


### PR DESCRIPTION
- Set the number of data columns in media library to be consistently 7
- Set number of images to 30 so page is scrollable on initial load
- Removed timeout for scrolling to prevent scrolling from being disabled if you scroll to bottom during that 1,5s window