### PR TITLE
Update PHPCS and WPCS rules

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Loader' ) ) {
 		 * Singleton creational pattern.
 		 * Makes sure there is only one instance at all times.
 		 *
-		 * @param array $services The Controller services to inject.
+		 * @param array  $services The Controller services to inject.
 		 * @param string $view_class The View class name.
 		 *
 		 * @return Loader
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Loader' ) ) {
 		 * after WordPress has finished loading but before any headers are sent.
 		 * Most of WP is loaded at this stage (but not all) and the user is authenticated.
 		 *
-		 * @param array $services The Controller services to inject.
+		 * @param array  $services The Controller services to inject.
 		 * @param string $view_class The View class name.
 		 */
 		private function __construct( $services = array(), $view_class ) {
@@ -85,7 +85,9 @@ if ( ! class_exists( 'Loader' ) ) {
 							'<u>' . esc_html__( 'Plugin Requirements Error!', 'planet4-medialibrary' ) . '</u><br /><br />' . esc_html( P4ML_PLUGIN_NAME ) . esc_html__( ' requires a newer version of the following plugin.', 'planet4-medialibrary' ) . '<br />' .
 							'<br/>' . esc_html__( 'Minimum required version of ', 'planet4-medialibrary' ) . esc_html( $plugin['Name'] ) . ': <strong>' . esc_html( $plugin['min_version'] ) . '</strong>' .
 							'<br/>' . esc_html__( 'Installed version of ', 'planet4-medialibrary' ) . esc_html( $plugin['Name'] ) . ': <strong>' . esc_html( $plugin['Version'] ) . '</strong>' .
-							'</div>', 'Plugin Requirements Error', array(
+							'</div>',
+							'Plugin Requirements Error',
+							array(
 								'response'  => \WP_Http::OK,
 								'back_link' => true,
 							)
@@ -98,7 +100,9 @@ if ( ! class_exists( 'Loader' ) ) {
 						'<u>' . esc_html__( 'Plugin Requirements Error!', 'planet4-medialibrary' ) . '</u><br /><br />' . esc_html( P4ML_PLUGIN_NAME . __( ' requires a newer version of PHP.', 'planet4-medialibrary' ) ) . '<br />' .
 						'<br/>' . esc_html__( 'Minimum required version of PHP: ', 'planet4-medialibrary' ) . '<strong>' . esc_html( $this->required_php ) . '</strong>' .
 						'<br/>' . esc_html__( 'Running version of PHP: ', 'planet4-medialibrary' ) . '<strong>' . esc_html( phpversion() ) . '</strong>' .
-						'</div>', 'Plugin Requirements Error', array(
+						'</div>',
+						'Plugin Requirements Error',
+						array(
 							'response'  => \WP_Http::OK,
 							'back_link' => true,
 						)
@@ -131,7 +135,7 @@ if ( ! class_exists( 'Loader' ) ) {
 					$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $required_plugin['rel_path'] );
 
 					if ( ! is_plugin_active( $required_plugin['rel_path'] ) ||
-					     ! version_compare( $plugin_data['Version'], $required_plugin['min_version'], '>=' ) ) {
+						 ! version_compare( $plugin_data['Version'], $required_plugin['min_version'], '>=' ) ) {
 						$plugin = array_merge( $plugin_data, $required_plugin );
 
 						return false;
@@ -177,7 +181,9 @@ if ( ! class_exists( 'Loader' ) ) {
 	wp_die(
 		'<div class="error fade">' .
 		'<u>' . esc_html__( 'Plugin Conflict Error!', 'planet4-medialibrary' ) . '</u><br /><br />' . esc_html__( 'Class Loader already exists.', 'planet4-medialibrary' ) . '<br />' .
-		'</div>', 'Plugin Conflict Error', array(
+		'</div>',
+		'Plugin Conflict Error',
+		array(
 			'response'  => \WP_Http::OK,
 			'back_link' => true,
 		)

--- a/classes/controller/class-api-controller.php
+++ b/classes/controller/class-api-controller.php
@@ -78,16 +78,19 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 				if ( false === $ml_auth_token ) {
 
 					// With the safe version of wp_remote_{VERB) functions, the URL is validated to avoid redirection and request forgery attacks.
-					$response = wp_safe_remote_post( $url, [
-						'body'      => [
-							'Login'    => $p4ml_login_id,
-							'Password' => $p4ml_password,
-							'format'   => 'json',
-						],
-						'timeout'   => self::ML_CALL_TIMEOUT,
-						'sslverify' => false,
+					$response = wp_safe_remote_post(
+						$url,
+						[
+							'body'      => [
+								'Login'    => $p4ml_login_id,
+								'Password' => $p4ml_password,
+								'format'   => 'json',
+							],
+							'timeout'   => self::ML_CALL_TIMEOUT,
+							'sslverify' => false,
 
-					] );
+						]
+					);
 
 					// Authentication failure.
 					if ( is_wp_error( $response ) ) {
@@ -149,10 +152,13 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 			}
 
 			// With the safe version of wp_remote_{VERB) functions, the URL is validated to avoid redirection and request forgery attacks.
-			$response = wp_remote_get( $url, [
-				'timeout'   => self::ML_CALL_TIMEOUT,
-				'sslverify' => false,
-			] );
+			$response = wp_remote_get(
+				$url,
+				[
+					'timeout'   => self::ML_CALL_TIMEOUT,
+					'sslverify' => false,
+				]
+			);
 
 			if ( is_wp_error( $response ) ) {
 				$response_data['status_code']   = $response->get_error_code();
@@ -228,12 +234,15 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 		 */
 		public function error( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
-					'type'    => self::ERROR,
-					'classes' => 'p4ml_error_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
+						'type'    => self::ERROR,
+						'classes' => 'p4ml_error_message',
+					]
+				);
 			}
 		}
 
@@ -245,12 +254,15 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 		 */
 		public function warning( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
-					'type'    => self::WARNING,
-					'classes' => 'p4ml_warning_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
+						'type'    => self::WARNING,
+						'classes' => 'p4ml_warning_message',
+					]
+				);
 			}
 		}
 
@@ -262,12 +274,15 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 		 */
 		public function notice( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
-					'type'    => self::NOTICE,
-					'classes' => 'p4ml_notice_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
+						'type'    => self::NOTICE,
+						'classes' => 'p4ml_notice_message',
+					]
+				);
 			}
 		}
 
@@ -279,12 +294,15 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 		 */
 		public function success( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
-					'type'    => self::SUCCESS,
-					'classes' => 'p4ml_success_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
+						'type'    => self::SUCCESS,
+						'classes' => 'p4ml_success_message',
+					]
+				);
 			}
 		}
 
@@ -304,10 +322,13 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 			$url = add_query_arg( $this->api_param, $url );
 
 			// With the safe version of wp_remote_{VERB) functions, the URL is validated to avoid redirection and request forgery attacks.
-			$response = wp_remote_get( $url, [
-				'timeout'   => self::ML_CALL_TIMEOUT,
-				'sslverify' => false,
-			] );
+			$response = wp_remote_get(
+				$url,
+				[
+					'timeout'   => self::ML_CALL_TIMEOUT,
+					'sslverify' => false,
+				]
+			);
 
 			if ( is_wp_error( $response ) ) {
 				return $response->get_error_message() . ' ' . $response->get_error_code();

--- a/classes/controller/class-uninstall-controller.php
+++ b/classes/controller/class-uninstall-controller.php
@@ -7,6 +7,7 @@ if ( ! class_exists( 'Uninstall_Controller' ) ) {
 	 * Planet4 - Media Library uninstaller
 	 *
 	 * Used when clicking "Delete" from inside of WordPress's plugins page.
+	 *
 	 * @package P4ML\Controllers
 	 */
 	class Uninstall_Controller {

--- a/classes/controller/menu/class-controller.php
+++ b/classes/controller/menu/class-controller.php
@@ -10,6 +10,7 @@ if ( ! class_exists( 'Controller' ) ) {
 	 * Class Controller
 	 *
 	 * This class will control all the main functions of the plugin.
+	 *
 	 * @package P4ML\Controllers\Menu
 	 */
 	abstract class Controller {
@@ -50,12 +51,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function error( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
-					'type'    => self::ERROR,
-					'classes' => 'p4ml_error_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
+						'type'    => self::ERROR,
+						'classes' => 'p4ml_error_message',
+					]
+				);
 			}
 		}
 
@@ -67,12 +71,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function warning( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
-					'type'    => self::WARNING,
-					'classes' => 'p4ml_warning_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
+						'type'    => self::WARNING,
+						'classes' => 'p4ml_warning_message',
+					]
+				);
 			}
 		}
 
@@ -84,12 +91,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function notice( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
-					'type'    => self::NOTICE,
-					'classes' => 'p4ml_notice_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
+						'type'    => self::NOTICE,
+						'classes' => 'p4ml_notice_message',
+					]
+				);
 			}
 		}
 
@@ -101,12 +111,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function success( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
-					'type'    => self::SUCCESS,
-					'classes' => 'p4ml_success_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
+						'type'    => self::SUCCESS,
+						'classes' => 'p4ml_success_message',
+					]
+				);
 			}
 		}
 	}

--- a/classes/controller/menu/class-settings-controller.php
+++ b/classes/controller/menu/class-settings-controller.php
@@ -35,12 +35,14 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 		 * Render the settings page of the plugin.
 		 */
 		public function prepare_settings() {
-			$this->view->settings( [
-				'settings'            => get_option( 'p4ml_main_settings' ),
-				'available_languages' => P4ML_LANGUAGES,
-				'messages'            => $this->messages,
-				'domain'              => 'planet4-medialibrary',
-			] );
+			$this->view->settings(
+				[
+					'settings'            => get_option( 'p4ml_main_settings' ),
+					'available_languages' => P4ML_LANGUAGES,
+					'messages'            => $this->messages,
+					'domain'              => 'planet4-medialibrary',
+				]
+			);
 		}
 
 		/**

--- a/classes/controller/tab/class-controller.php
+++ b/classes/controller/tab/class-controller.php
@@ -10,6 +10,7 @@ if ( ! class_exists( 'Controller' ) ) {
 	 * Class Controller
 	 *
 	 * This class will control all the main functions of the plugin.
+	 *
 	 * @package P4ML\Controllers\Tab
 	 */
 	abstract class Controller {
@@ -49,12 +50,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function error( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
-					'type'    => self::ERROR,
-					'classes' => 'p4ml_error_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Error', 'planet4-medialibrary' ),
+						'type'    => self::ERROR,
+						'classes' => 'p4ml_error_message',
+					]
+				);
 			}
 		}
 
@@ -66,12 +70,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function warning( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
-					'type'    => self::WARNING,
-					'classes' => 'p4ml_warning_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Warning', 'planet4-medialibrary' ),
+						'type'    => self::WARNING,
+						'classes' => 'p4ml_warning_message',
+					]
+				);
 			}
 		}
 
@@ -83,12 +90,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function notice( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
-					'type'    => self::NOTICE,
-					'classes' => 'p4ml_notice_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Notice', 'planet4-medialibrary' ),
+						'type'    => self::NOTICE,
+						'classes' => 'p4ml_notice_message',
+					]
+				);
 			}
 		}
 
@@ -100,12 +110,15 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		public function success( $msg, $title = '' ) {
 			if ( is_string( $msg ) ) {
-				array_push($this->messages, [
-					'msg'     => esc_html( $msg ),
-					'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
-					'type'    => self::SUCCESS,
-					'classes' => 'p4ml_success_message',
-				] );
+				array_push(
+					$this->messages,
+					[
+						'msg'     => esc_html( $msg ),
+						'title'   => $title ? esc_html( $title ) : esc_html__( 'Success', 'planet4-medialibrary' ),
+						'type'    => self::SUCCESS,
+						'classes' => 'p4ml_success_message',
+					]
+				);
 			}
 		}
 	}

--- a/classes/controller/tab/class-gpi-media-library-controller.php
+++ b/classes/controller/tab/class-gpi-media-library-controller.php
@@ -29,12 +29,12 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 		public function __construct( View $view ) {
 			parent::__construct( $view );
 
-			add_filter( 'media_upload_tabs',                    [ $this, 'media_library_tab' ] );
-			add_action( 'media_upload_gpi_media_library',       [ $this, 'add_library_form' ] );
+			add_filter( 'media_upload_tabs', [ $this, 'media_library_tab' ] );
+			add_action( 'media_upload_gpi_media_library', [ $this, 'add_library_form' ] );
 			add_action( 'wp_ajax_download_images_from_library', [ $this, 'download_images_from_library' ] );
-			add_action( 'wp_ajax_get_paged_medias',             [ $this, 'get_paged_medias' ] );
-			add_action( 'wp_ajax_get_search_medias',            [ $this, 'get_search_medias' ] );
-			add_action( 'post-upload-ui',                       [ $this, 'media_library_post_upload_ui' ] );
+			add_action( 'wp_ajax_get_paged_medias', [ $this, 'get_paged_medias' ] );
+			add_action( 'wp_ajax_get_search_medias', [ $this, 'get_search_medias' ] );
+			add_action( 'post-upload-ui', [ $this, 'media_library_post_upload_ui' ] );
 		}
 
 		/**
@@ -78,13 +78,15 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 			}
 
 			$this->load_iframe_assets();
-			$this->view->ml_view( [
-				'data' => [
-					'image_list'    => $image_list['result'],
-					'error_message' => $error_message,
-					'domain'        => 'planet4-medialibrary',
-				],
-			] );
+			$this->view->ml_view(
+				[
+					'data' => [
+						'image_list'    => $image_list['result'],
+						'error_message' => $error_message,
+						'domain'        => 'planet4-medialibrary',
+					],
+				]
+			);
 		}
 
 		/**
@@ -115,13 +117,15 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 					$error_message = __( 'Error while fetching data from remote server!!!', 'planet4-medialibrary' );
 				}
 
-				$this->view->ml_search_view( [
-					'data' => [
-						'image_list'    => $image_list['result'],
-						'error_message' => $error_message,
-						'domain'        => 'planet4-medialibrary',
-					],
-				] );
+				$this->view->ml_search_view(
+					[
+						'data' => [
+							'image_list'    => $image_list['result'],
+							'error_message' => $error_message,
+							'domain'        => 'planet4-medialibrary',
+						],
+					]
+				);
 
 				wp_die();
 			}
@@ -157,21 +161,25 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 				}
 
 				if ( 'true' === $search_flag ) {
-					$this->view->ml_search_media_view( [
-						'data' => [
-							'image_list'    => $image_list['result'],
-							'error_message' => $error_message,
-							'domain'        => 'planet4-medialibrary',
-						],
-					] );
+					$this->view->ml_search_media_view(
+						[
+							'data' => [
+								'image_list'    => $image_list['result'],
+								'error_message' => $error_message,
+								'domain'        => 'planet4-medialibrary',
+							],
+						]
+					);
 				} else {
-					$this->view->ml_media_view( [
-						'data' => [
-							'image_list'    => $image_list['result'],
-							'error_message' => $error_message,
-							'domain'        => 'planet4-medialibrary',
-						],
-					] );
+					$this->view->ml_media_view(
+						[
+							'data' => [
+								'image_list'    => $image_list['result'],
+								'error_message' => $error_message,
+								'domain'        => 'planet4-medialibrary',
+							],
+						]
+					);
 				}
 
 				wp_die();

--- a/classes/helper/class-media-helper.php
+++ b/classes/helper/class-media-helper.php
@@ -25,12 +25,14 @@ class MediaHelper {
 		$file     = $url;
 		$filename = basename( $file );
 
-		$context = stream_context_create( [
-			'ssl' => [
-				'verify_peer'      => false,
-				'verify_peer_name' => false,
-			],
-		]);
+		$context = stream_context_create(
+			[
+				'ssl' => [
+					'verify_peer'      => false,
+					'verify_peer_name' => false,
+				],
+			]
+		);
 
 		// Upload file into WP upload dir.
 		$upload_file = wp_upload_bits( $filename, null, file_get_contents( $url, false, $context ) );
@@ -88,7 +90,6 @@ class MediaHelper {
 		} else {
 			return $upload_file['error'];
 		}
-
 
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,9 @@
     }
   ],
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.9.*",
-    "wp-coding-standards/wpcs": "0.13.*",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0",
-    "frenck/php-compatibility": "^7.1"
+    "squizlabs/php_codesniffer": "^3.4.2",
+    "wp-coding-standards/wpcs": "^2.1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0"
   },
   "require": {},
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "529cf056abb28a464be1dc48d1eca26f",
+    "content-hash": "51629934e51862a427a9bbad2f45bf3c",
     "packages": [],
     "packages-dev": [
         {
@@ -76,112 +76,37 @@
             "time": "2017-12-06T16:27:17+00:00"
         },
         {
-            "name": "frenck/php-compatibility",
-            "version": "7.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/frenck/PHPCompatibility.git",
-                "reference": "9364ba95121843ea9b86305d9c3582f1a85e10ff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/frenck/PHPCompatibility/zipball/9364ba95121843ea9b86305d9c3582f1a85e10ff",
-                "reference": "9364ba95121843ea9b86305d9c3582f1a85e10ff",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.1.2",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "require-dev": {
-                "satooshi/php-coveralls": "dev-master"
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "This is a set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility, composer compatible.",
-            "homepage": "http://github.com/frenck/PHPCompatibility",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "abandoned": "wimg/php-compatibility",
-            "time": "2017-02-24T14:15:44+00:00"
-        },
-        {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -194,33 +119,38 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.13.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
+                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -239,7 +169,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-08-05T16:08:58+00:00"
+            "time": "2019-05-21T02:50:00+00:00"
         }
     ],
     "aliases": [],

--- a/planet4-gpi-media-library.php
+++ b/planet4-gpi-media-library.php
@@ -26,29 +26,60 @@
 defined( 'ABSPATH' ) || die( 'Direct access is forbidden !' );
 
 
-/* ========================
-      C O N S T A N T S
+/*
+ ========================
+	  C O N S T A N T S
    ======================== */
-if ( ! defined( 'P4ML_REQUIRED_PHP' ) )        define( 'P4ML_REQUIRED_PHP',       '7.0' );
-if ( ! defined( 'P4ML_REQUIRED_PLUGINS' ) )    define( 'P4ML_REQUIRED_PLUGINS',   [
-	'timber' => [
-		'min_version' => '1.3.0',
-		'rel_path'    => 'timber-library/timber.php',
-	],
-] );
-if ( ! defined( 'P4ML_PLUGIN_BASENAME' ) )     define( 'P4ML_PLUGIN_BASENAME',    plugin_basename( __FILE__ ) );
-if ( ! defined( 'P4ML_PLUGIN_DIRNAME' ) )      define( 'P4ML_PLUGIN_DIRNAME',     dirname( P4ML_PLUGIN_BASENAME ) );
-if ( ! defined( 'P4ML_PLUGIN_DIR' ) )          define( 'P4ML_PLUGIN_DIR',         WP_PLUGIN_DIR . '/' . P4ML_PLUGIN_DIRNAME );
-if ( ! defined( 'P4ML_PLUGIN_NAME' ) )         define( 'P4ML_PLUGIN_NAME',        'Planet4 - Gpi Media Library' );
-if ( ! defined( 'P4ML_PLUGIN_SHORT_NAME' ) )   define( 'P4ML_PLUGIN_SHORT_NAME',  'GpiMediaLibrary' );
-if ( ! defined( 'P4ML_PLUGIN_SLUG_NAME' ) )    define( 'P4ML_PLUGIN_SLUG_NAME',   'gpimedialibrary' );
-if ( ! defined( 'P4ML_INCLUDES_DIR' ) )        define( 'P4ML_INCLUDES_DIR',       P4ML_PLUGIN_DIR . '/includes/' );
-if ( ! defined( 'P4ML_ADMIN_DIR' ) )           define( 'P4ML_ADMIN_DIR',          plugins_url( P4ML_PLUGIN_DIRNAME . '/admin/' ) );
-if ( ! defined( 'P4ML_LANGUAGES' ) )           define( 'P4ML_LANGUAGES',          [
-	'en_US' => 'English',
-	'el_GR' => 'Ελληνικά',
-] );
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) )      define( 'WP_UNINSTALL_PLUGIN',     P4ML_PLUGIN_BASENAME );
+if ( ! defined( 'P4ML_REQUIRED_PHP' ) ) {
+	define( 'P4ML_REQUIRED_PHP', '7.0' );
+}
+if ( ! defined( 'P4ML_REQUIRED_PLUGINS' ) ) {
+	define(
+		'P4ML_REQUIRED_PLUGINS',
+		[
+			'timber' => [
+				'min_version' => '1.3.0',
+				'rel_path'    => 'timber-library/timber.php',
+			],
+		]
+	);
+}
+if ( ! defined( 'P4ML_PLUGIN_BASENAME' ) ) {
+	define( 'P4ML_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+}
+if ( ! defined( 'P4ML_PLUGIN_DIRNAME' ) ) {
+	define( 'P4ML_PLUGIN_DIRNAME', dirname( P4ML_PLUGIN_BASENAME ) );
+}
+if ( ! defined( 'P4ML_PLUGIN_DIR' ) ) {
+	define( 'P4ML_PLUGIN_DIR', WP_PLUGIN_DIR . '/' . P4ML_PLUGIN_DIRNAME );
+}
+if ( ! defined( 'P4ML_PLUGIN_NAME' ) ) {
+	define( 'P4ML_PLUGIN_NAME', 'Planet4 - Gpi Media Library' );
+}
+if ( ! defined( 'P4ML_PLUGIN_SHORT_NAME' ) ) {
+	define( 'P4ML_PLUGIN_SHORT_NAME', 'GpiMediaLibrary' );
+}
+if ( ! defined( 'P4ML_PLUGIN_SLUG_NAME' ) ) {
+	define( 'P4ML_PLUGIN_SLUG_NAME', 'gpimedialibrary' );
+}
+if ( ! defined( 'P4ML_INCLUDES_DIR' ) ) {
+	define( 'P4ML_INCLUDES_DIR', P4ML_PLUGIN_DIR . '/includes/' );
+}
+if ( ! defined( 'P4ML_ADMIN_DIR' ) ) {
+	define( 'P4ML_ADMIN_DIR', plugins_url( P4ML_PLUGIN_DIRNAME . '/admin/' ) );
+}
+if ( ! defined( 'P4ML_LANGUAGES' ) ) {
+	define(
+		'P4ML_LANGUAGES',
+		[
+			'en_US' => 'English',
+			'el_GR' => 'Ελληνικά',
+		]
+	);
+}
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	define( 'WP_UNINSTALL_PLUGIN', P4ML_PLUGIN_BASENAME );
+}
 
 
 
@@ -56,10 +87,14 @@ require_once __DIR__ . '/vendor/autoload.php';
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 
-/* ==========================
-      L O A D  P L U G I N
+/*
+ ==========================
+	  L O A D  P L U G I N
    ========================== */
-P4ML\Loader::get_instance( [
-	'P4ML\Controllers\Menu\Settings_Controller',
-	'P4ML\Controllers\Tab\GPI_Media_Library_Controller',
-], 'P4ML\Views\View' );
+P4ML\Loader::get_instance(
+	[
+		'P4ML\Controllers\Menu\Settings_Controller',
+		'P4ML\Controllers\Tab\GPI_Media_Library_Controller',
+	],
+	'P4ML\Views\View'
+);


### PR DESCRIPTION
There is a problem with an outdated dependency:

<img width="917" alt="Captura de pantalla 2019-07-03 a la(s) 13 42 25" src="https://user-images.githubusercontent.com/340766/60609989-38cc9700-9d99-11e9-8810-1996c15ec4dc.png">

I updated the PHPCS and WPCS versions to match those of the Blocks plugin. I also ran PHPCBF in a separate commit, in case we want to remove it. Feel free to discard it if needed.
