### PR TITLE
PLANET-4623: Some Code Included in the Social Media Share Excerpt

### DIFF
--- a/admin/js/adminml.js
+++ b/admin/js/adminml.js
@@ -91,17 +91,17 @@ jQuery(document).ready(function () {
                     }
                     //TODO handle promises results/errors better.
                     Promise.all(promises).then(function (values) {
-                        parent.send_to_editor(values.join(' '));
+                        // Close the thickbox (closes the GPI Media Library UI),
+                        // goes back to selecting uploaded media.
+                        if ( parent.tb_remove ) {
+                            parent.tb_remove();
+                        }
                     });
                 }
             } catch (e) {
             }
-            $( '#ml_spinner' ).removeClass('is-active');
-            // If this is not a page with a wp editor, then move to the Media Library page.
-            if ( "function" !== typeof parent.send_to_editor ) {
-                parent.window.location.replace('./upload.php');
-            }
 
+            $( '#ml_spinner' ).removeClass('is-active');
         }).fail(function (jqXHR, textStatus, errorThrown) {
             console.log(errorThrown); //eslint-disable-line no-console
             $( '#ml_spinner' ).removeClass('is-active');

--- a/classes/controller/tab/class-gpi-media-library-controller.php
+++ b/classes/controller/tab/class-gpi-media-library-controller.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 		 */
 		public function media_library_post_upload_ui() {
 			$this->load_ml_assets();
-			print '<button id="db-upload-btn" class="button media-button button-primary button-large insert-media add_media switchtoml">' . esc_html__( 'Upload From GPI Media Library', 'planet4-medialibrary' ) . '</button>';
+			print '<button id="db-upload-btn" class="button media-button button-primary button-large add_media switchtoml">' . esc_html__( 'Upload From GPI Media Library', 'planet4-medialibrary' ) . '</button>';
 		}
 
 		/**
@@ -201,7 +201,7 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 			];
 
 			wp_enqueue_style( 'p4ml_admin_style', P4ML_ADMIN_DIR . 'css/admin.css', [ 'media-views', 'media' ], '0.9' );
-			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/adminml.js', [], '0.14', true );
+			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/adminml.js', [], '0.15', true );
 			wp_localize_script( 'p4ml_admin_script', 'media_library_params', $params );
 			wp_enqueue_script( 'jquery-ui-core' );
 			wp_enqueue_script( 'jquery-ui-selectable' );
@@ -221,7 +221,7 @@ if ( ! class_exists( 'GPI_Media_Library_Controller' ) ) {
 			];
 
 			wp_enqueue_style( 'p4ml_admin_style', P4ML_ADMIN_DIR . 'css/admin_search_ml.css', [], '0.5' );
-			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/admin_search_ml.js', [], '0.4.3', true );
+			wp_register_script( 'p4ml_admin_script', P4ML_ADMIN_DIR . 'js/admin_search_ml.js', [], '0.4.4', true );
 			wp_localize_script( 'p4ml_admin_script', 'media_library_params', $params );
 			wp_enqueue_script( 'p4ml_admin_script' );
 			wp_enqueue_media();


### PR DESCRIPTION
This is the bug:

- When you selected an image from the GPI Media Library, there was a call to the `send_to_editor` function (https://github.com/WordPress/WordPress/blob/aea25de893afa9be9bfb6e09f67a0d73691c3d0e/wp-admin/js/media-upload.js#L29), which added the image's shortcode to any active TinyMCE editor, it could be the Open Graph Description, or even the Header Description. I guess this was working in the classic editor before moving to Gutenberg, it doesn't make much sense anymore. 

So I replicated the last part of it (https://github.com/WordPress/WordPress/blob/aea25de893afa9be9bfb6e09f67a0d73691c3d0e/wp-admin/js/media-upload.js#L59) which closes the "Thickbox", in essence, it moves the user back to the Media Selector screen, but skips inserting the shortcode in any TinyMCE editors there. 

I also removed a redirection to `upload.php` which was causing the window to trigger a `onbeforeunload` dialog. I'm not sure if this could have any side-effects, but as a hotfix I think it does the job and we need to do a thorough refactor to the Media Library plugin anyway.

Test env: https://k8s.p4.greenpeace.org/test-phobos/

Ref: https://jira.greenpeace.org/browse/PLANET-4623
