### PR TITLE
Remove psr-4 config and add Twig dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,5 @@
     "squizlabs/php_codesniffer": "^3.4.2",
     "wp-coding-standards/wpcs": "^2.1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0"
-  },
-  "require": {},
-  "autoload": {
-    "psr-4": {
-      "P4ML\\": "classes/",
-      "P4ML\\Controllers\\": "classes/controller/",
-      "P4ML\\Controllers\\Menu\\": "classes/controller/menu"
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
     "squizlabs/php_codesniffer": "^3.4.2",
     "wp-coding-standards/wpcs": "^2.1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0"
+  },
+  "require": {
+    "wpackagist-plugin/timber-library": "1.*"
   }
 }


### PR DESCRIPTION
It's probably not used in our case, and causes issues if other people
try to install the plugin.