### PR TITLE
Fix copyright value

### DIFF
--- a/classes/api/class-media-image-mapper.php
+++ b/classes/api/class-media-image-mapper.php
@@ -21,7 +21,7 @@ class MediaImageMapper {
 			->set_id( (string) $params['SystemIdentifier'] )
 			->set_title( (string) $params['Title'] )
 			->set_caption( (string) $params['Caption'] )
-			->set_credit( $params['copyright'] ?? '' )
+			->set_credit( $params['CoreField.Copyright'] ?? '' )
 			->set_media_restrictions( $params['restrictions'] ?? '' )
 			->set_path_tr1( (string) $params['Path_TR1']['URI'] )
 			->set_original_language_title( $params['original-language-title'] ?? '' )

--- a/classes/controller/class-api-controller.php
+++ b/classes/controller/class-api-controller.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 
 			$this->api_param = [
 				'query'        => '(Mediatype:Image)',
-				'fields'       => 'Title,Caption,copyright,Path_TR1,Path_TR1_COMP_SMALL,Path_TR7,Path_TR4,Path_TR1_COMP,Path_TR2,Path_TR3,SystemIdentifier,original-language-title,original-language-description,original-language,restrictions,copyright',
+				'fields'       => 'Title,Caption,CoreField.Copyright,Path_TR1,Path_TR1_COMP_SMALL,Path_TR7,Path_TR4,Path_TR1_COMP,Path_TR2,Path_TR3,SystemIdentifier,original-language-title,original-language-description,original-language,restrictions',
 				'countperpage' => self::MEDIAS_PER_PAGE,
 				'format'       => 'json',
 				'token'        => $this->ml_auth_token,
@@ -196,7 +196,7 @@ if ( ! class_exists( 'MediaLibraryApi_Controller' ) ) {
 			if ( is_array( $details ) && $details ) {
 				$media_details['image_title']   = $details['Title'];
 				$media_details['image_caption'] = $details['Caption'];
-				$media_details['image_credit']  = $details['copyright'];
+				$media_details['image_credit']  = $details['CoreField.Copyright'];
 				$media_details['gpml_image_id'] = $details['SystemIdentifier'];
 
 				if ( $details['Path_TR7']['URI'] ) {


### PR DESCRIPTION
Ref: [PLANET-6923](https://jira.greenpeace.org/browse/PLANET-6923)

After debugging the library, I noticed that original copyright field it's always returning an empty `string`. Looking at the API fields, I figure out there is another field `CoreField.Copyright`, which set the Credits or Copyrights. That could be part of their latest update.

## Testing
First, here is the API endpoint to retrieve all available fields
https://media.greenpeace.org/API/search/v3.0/ListFields

```xml
<Result>
    <APIRequestInfo>
        <ProviderVersion>ANN_ARBOR.R4.1837G.206397</ProviderVersion>
        <ProviderIdentity>GPC-EUW1-P-APP</ProviderIdentity>
        <ProviderID>09d30c887ca750ca847f872eadeb3f5c</ProviderID>
        <Module>search</Module>
        <APIVersion>v3.0</APIVersion>
        <Resource>ListFields</Resource>
        <IsLoggedIn type="Boolean">True</IsLoggedIn>
        <Status>LoggedIn</Status>
        <UserLogin>GP0CT20894</UserLogin>
        <TimeoutPeriodMinutes type="Numeric">1440</TimeoutPeriodMinutes>
    </APIRequestInfo>
    <APIResponse>
        <Metadata>
            ....
            <copyright>Credit line</copyright>
            ....
            <CoreField.Copyright>credit line</CoreField.Copyright>
            ....
        </Metadata>
    </APIResponse>
</Result>
```

Steps to reproduce and validate the issue
1. Go to `Media > Library` and click on 
2. Click on `Import`
3. Click on `Upload From GPI Media Library`
4. Wait for a couple of seconds and wait after all the images appear.
5. Click on any picture and see if the Credit field it's filled. It should.
![Screenshot 2023-01-23 at 10 47 36](https://user-images.githubusercontent.com/77975803/214055755-10c378ab-df8c-49f5-9198-9d138efa061d.png)


Take in mind that you need a `token` for testing

